### PR TITLE
Improve packaging and test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.coverage
+.tox
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 env:
     - TOX_ENV=py26
     - TOX_ENV=py27
-    - TOX_ENV=py32
     - TOX_ENV=py33
     - TOX_ENV=py34
     - TOX_ENV=pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=py33
     - TOX_ENV=py34
+    - TOX_ENV=py35
     - TOX_ENV=pypy
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "3.2"
-    - "3.3"
-    - "3.4"
-    - "pypy"
+env:
+    - TOX_ENV=py26
+    - TOX_ENV=py27
+    - TOX_ENV=py32
+    - TOX_ENV=py33
+    - TOX_ENV=py34
+    - TOX_ENV=pypy
 
 install:
-    - pip install coverage toolz multipledispatch --use-mirrors
+    - pip install tox --use-mirrors
 
 script:
-    - nosetests --with-doctest
+    - tox -e $TOX_ENV
 
 after_success:
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls --use-mirrors ; coveralls ; fi

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
 from os.path import exists
+import re
 from setuptools import setup
-import unification
+
+contents = re.findall(
+    r'__version__ = \'([.0-9]+)\'',
+    open('unification/__init__.py', 'r').read())[0]
 
 setup(name='unification',
-      version=unification.__version__,
+      version=contents,
       description='Unification',
       url='http://github.com/mrocklin/unification/',
       author='https://raw.github.com/mrocklin/unification/master/AUTHORS.md',

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-from os.path import exists
+from os.path import exists, join
 import re
 from setuptools import setup
 
-contents = re.findall(
+version = re.findall(
     r'__version__ = \'([.0-9]+)\'',
-    open('unification/__init__.py', 'r').read())[0]
+    open(join('unification', '__init__.py'), 'r').read())[0]
 
 setup(name='unification',
-      version=contents,
+      version=version,
       description='Unification',
       url='http://github.com/mrocklin/unification/',
       author='https://raw.github.com/mrocklin/unification/master/AUTHORS.md',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 install_command = pip install {opts} {packages} --use-mirrors
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py33,py34,py35,pypy
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 install_command = pip install {opts} {packages} --use-mirrors
-envlist = py26,py27,py32,py33,py34,pypy
+envlist = py26,py27,py33,py34,pypy
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+install_command = pip install {opts} {packages} --use-mirrors
+envlist = py26,py27,py32,py33,py34,pypy
+
+[testenv]
+usedevelop = True
+commands =
+  nosetests {posargs:--with-doctest --with-coverage --cover-package=unification} -v
+deps =
+  coverage
+  nose

--- a/unification/__init__.py
+++ b/unification/__init__.py
@@ -2,4 +2,4 @@ from .core import unify, reify
 from .more import unifiable
 from .variable import var, isvar, vars, variables, Var
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/unification/tests/test_core.py
+++ b/unification/tests/test_core.py
@@ -52,6 +52,7 @@ def test_unify_dict():
     assert unify({1: 2}, {1: 2}, {}) == {}
     assert unify({1: 2}, {1: 3}, {}) == False
     assert unify({2: 2}, {1: 2}, {}) == False
+    assert unify({2: 2, 3: 3}, {1: 2}, {}) == False
     assert unify({1: var(5)}, {1: 2}, {}) == {var(5): 2}
 
 def test_unify_complex():

--- a/unification/tests/test_more.py
+++ b/unification/tests/test_more.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from unification.more import (unify_object, reify_object,
         unifiable)
 from unification import var, variables
@@ -32,6 +34,17 @@ def test_reify_object():
     f = Foo(1, 2)
     assert reify_object(f, {}) is f
 
+def test_reify_slots():
+    SlotsObject = namedtuple('SlotsObject', ['myattr'])
+    class SlotsObject(object):
+        __slots__ = ['myattr']
+        def __init__(self, myattr):
+            self.myattr = myattr
+    x = var()
+    s = {x: 1}
+    e = SlotsObject(x)
+    assert reify_object(e, s), SlotsObject(1)
+    assert reify_object(SlotsObject(1), s), SlotsObject(1)
 
 def test_objects_full():
     _unify.add((Foo, Foo, dict), unify_object)

--- a/unification/tests/test_more.py
+++ b/unification/tests/test_more.py
@@ -35,11 +35,12 @@ def test_reify_object():
     assert reify_object(f, {}) is f
 
 def test_reify_slots():
-    SlotsObject = namedtuple('SlotsObject', ['myattr'])
+
     class SlotsObject(object):
         __slots__ = ['myattr']
         def __init__(self, myattr):
             self.myattr = myattr
+
     x = var()
     s = {x: 1}
     e = SlotsObject(x)

--- a/unification/tests/test_utils.py
+++ b/unification/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unification.utils import raises, hashable
+from unification.utils import freeze, hashable, raises
 
 def test_hashable():
     assert hashable(2)
@@ -9,3 +9,9 @@ def test_hashable():
 def test_raises():
     assert raises(ZeroDivisionError, lambda: 1/0)
     assert not raises(ZeroDivisionError, lambda: 0/1)
+
+
+def test_freeze():
+    assert freeze({1: [2, 3]}) == frozenset([(1, (2, 3))])
+    assert freeze(set([1])) == frozenset([1])
+    assert freeze(([1], )) == ((1, ), )

--- a/unification/utils.py
+++ b/unification/utils.py
@@ -24,10 +24,6 @@ def transitive_get(key, d):
     return key
 
 
-def dicthash(d):
-    return hash(frozenset(d.items()))
-
-
 def raises(err, lamda):
     try:
         lamda()
@@ -96,7 +92,7 @@ def reverse_dict(d):
 def xfail(func):
     try:
         func()
-        raise Exception("XFailed test passed")
+        raise Exception("XFailed test passed")  # pragma:nocover
     except:
         pass
 


### PR DESCRIPTION
@mrocklin This pull request does the following:
## Packaging

Fixes an issue wherein the dependencies need to be installed to even evaluate what the dependencies are. This leads to failures like the following when installing this package in a fresh virtualenv:

``` pytb
(foo)/tmp/foo $ pip install unification
[...]
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/0c/wgg0rggj7qn9c5yc1gs5w5lr0000gp/T/pip-build-vwGGU5/unification/setup.py", line 5, in <module>
        import unification
      File "unification/__init__.py", line 1, in <module>
        from .core import unify, reify
      File "unification/core.py", line 3, in <module>
        from toolz.compatibility import iteritems, map
    ImportError: No module named toolz.compatibility
```

This was caused by importing `unification.__version__`, which attempted to import `toolz`.  I fixed it by using a regular expression on the contents of `unification/__init__.py` to determine the version instead of a python import.
## Test Environment

I added a tox.ini file to make running the test suite easier.  Travis is awesome, but it requires a lot of setup to reproduce the tests locally.  I updated `.travis.yml` to use `tox` following [this blog post](https://www.dominicrodger.com/2013/07/26/tox-and-travis/). It's a bit difficult to reproduce issues with it locally [short of running in a docker container](http://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally), and `tox` seems to be the standard for running paramterized test suites in Python nowadays.
## Test Coverage

I added a few tests to push test coverage up to 100%. I removed the `dicthash` method, since it seems to be unused.
## Thanks!

Thanks for putting this package together! It looks like it'll be really useful!
