### PR TITLE
fix(core): deprecation warning with Python 3.7

### DIFF
--- a/unification/core.py
+++ b/unification/core.py
@@ -1,5 +1,5 @@
 from functools import partial
-from collections import Iterator
+from collections.abc import Iterator
 from toolz.compatibility import iteritems, map
 from toolz import assoc
 


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working